### PR TITLE
Terraform 0.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,19 @@
 # Create Security Group
 resource "huaweicloud_networking_secgroup_v2" "this" {
-  count                = "${var.security_group_id=="" ? 1 : 0}"
-  name                 = "${var.name}"
-  description          = "${var.description}"
-  delete_default_rules = "${var.delete_default_rules}"
+  count                = var.security_group_id == "" ? 1 : 0
+  name                 = var.name
+  description          = var.description
+  delete_default_rules = var.delete_default_rules
 }
 
 # Create Security Group Rule
 resource "huaweicloud_networking_secgroup_rule_v2" "this" {
-  count 			= "${length(var.rules)}"
-  direction         = "${lookup(var.rules[count.index], "direction")}"
-  ethertype         = "${lookup(var.rules[count.index], "ethertype")}"
-  protocol          = "${lookup(var.rules[count.index], "protocol")}"
-  port_range_min    = "${lookup(var.rules[count.index], "port_range_min")}"
-  port_range_max    = "${lookup(var.rules[count.index], "port_range_max")}"
-  remote_ip_prefix  = "${lookup(var.rules[count.index], "remote_ip_cidr")}"
-  security_group_id = "${var.security_group_id=="" ? join("",huaweicloud_networking_secgroup_v2.this.*.id) : var.security_group_id}"
+  count             = length(var.rules)
+  direction         = var.rules[count.index]["direction"]
+  ethertype         = var.rules[count.index]["ethertype"]
+  protocol          = var.rules[count.index]["protocol"]
+  port_range_min    = var.rules[count.index]["port_range_min"]
+  port_range_max    = var.rules[count.index]["port_range_max"]
+  remote_ip_prefix  = var.rules[count.index]["remote_ip_cidr"]
+  security_group_id = var.security_group_id == "" ? join("", huaweicloud_networking_secgroup_v2.this.*.id) : var.security_group_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "this_security_group_id" {
-    description = "The ID of the security group"
-    value       = "${var.security_group_id=="" ? join("",huaweicloud_networking_secgroup_v2.this.*.id) : var.security_group_id}"
+  description = "The ID of the security group"
+  value       = var.security_group_id == "" ? join("", huaweicloud_networking_secgroup_v2.this.*.id) : var.security_group_id
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,15 @@ variable "delete_default_rules" {
 }
 
 variable "rules" {
-  type = list(map(string))
+  type = list(object({
+    direction      = string
+    ethertype      = string
+    protocol       = string
+    port_range_min = string
+    port_range_max = string
+    remote_ip_cidr = string
+  }))
   description = "List of rules in a security group"
   default     = []
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
```terraform
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.security_group_ssh.huaweicloud_networking_secgroup_rule_v2.this[0] will be created
  + resource "huaweicloud_networking_secgroup_rule_v2" "this" {
      + direction         = "ingress"
      + ethertype         = "IPv4"
      + id                = (known after apply)
      + port_range_max    = 22
      + port_range_min    = 22
      + protocol          = "tcp"
      + region            = (known after apply)
      + remote_group_id   = (known after apply)
      + remote_ip_prefix  = "0.0.0.0/0"
      + security_group_id = (known after apply)
      + tenant_id         = (known after apply)
    }

  # module.security_group_ssh.huaweicloud_networking_secgroup_v2.this[0] will be created
  + resource "huaweicloud_networking_secgroup_v2" "this" {
      + delete_default_rules = true
      + description          = "Allowing ssh access"
      + id                   = (known after apply)
      + name                 = "ssh"
      + region               = (known after apply)
      + tenant_id            = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```